### PR TITLE
Fix when member type is unknown

### DIFF
--- a/Trine.Analyzer.Tests/MemberOrderTests.cs
+++ b/Trine.Analyzer.Tests/MemberOrderTests.cs
@@ -36,6 +36,10 @@ namespace Trine
         int anotherNonConstField;
         const int constField = 1;
 
+        public static bool operator ==(TestClass p1, TestClass p2) {
+            return true;
+        }
+
         // Keep comment
         protected TestClass() {}
 
@@ -81,14 +85,14 @@ namespace Trine
                     Id = "TRINE01",
                     Message = "Public should be declared before Protected",
                     Severity = DiagnosticSeverity.Warning,
-                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 18, 9)}
+                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 22, 9)}
                 },
                 new DiagnosticResult
                 {
                     Id = "TRINE01",
                     Message = "Static should be declared before NonStatic",
                     Severity = DiagnosticSeverity.Warning,
-                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 21, 9)}
+                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 25, 9)}
                 },
             });
 
@@ -118,6 +122,10 @@ namespace Trine
         public void Method() {}
 
         public class SubClass {}
+
+        public static bool operator ==(TestClass p1, TestClass p2) {
+            return true;
+        }
     }
 }
 ";

--- a/Trine.Analyzer/MemberOrderAnalyzer.cs
+++ b/Trine.Analyzer/MemberOrderAnalyzer.cs
@@ -29,12 +29,12 @@ namespace Trine.Analyzer
             foreach (var member in cls.Members)
             {
                 var sortOrder = new SortOrder(member);
-                if (prevSortOrder != null)
+                if (prevSortOrder != null
+                    && prevSortOrder.IsKnown
+                    && sortOrder.IsKnown
+                    && sortOrder.CompareTo(prevSortOrder) < 0)
                 {
-                    if (sortOrder.CompareTo(prevSortOrder) < 0)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation(), SortOrder.FormatOrderDifference(sortOrder, prevSortOrder)));
-                    }
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation(), SortOrder.FormatOrderDifference(sortOrder, prevSortOrder)));
                 }
 
                 prevSortOrder = sortOrder;

--- a/Trine.Analyzer/SortOrder.cs
+++ b/Trine.Analyzer/SortOrder.cs
@@ -21,6 +21,8 @@ namespace Trine.Analyzer
 
         public DeclarationOrder? Declaration => _declarationOrder;
 
+        public bool IsKnown => _declarationOrder != null && _visibilityOrder != null && _staticOrder != null;
+
         public static string[] FormatOrderDifference(SortOrder sortOrder1, SortOrder sortOrder2)
         {
             if (sortOrder1._declarationOrder != sortOrder2._declarationOrder) return FormatItems(sortOrder1._declarationOrder, sortOrder2._declarationOrder);
@@ -49,7 +51,10 @@ namespace Trine.Analyzer
 
         private static int? CompareOrder<T>(T? order1, T? order2) where T : struct, IComparable
         {
-            if (!order1.HasValue || !order2.HasValue) return null;
+            if (!order1.HasValue && order2.HasValue) return 1;
+            if (order1.HasValue && !order2.HasValue) return -1;
+            if (!order1.HasValue && !order2.HasValue) return 0;
+            
             var diff = order1.Value.CompareTo(order2.Value);
             if (diff == 0) return null;
             return diff;
@@ -124,7 +129,8 @@ namespace Trine.Analyzer
             if (member is BaseFieldDeclarationSyntax field) return field.Modifiers;
             if (member is BasePropertyDeclarationSyntax property) return property.Modifiers;
             if (member is ClassDeclarationSyntax @class) return @class.Modifiers;
-            throw new Exception("Unnknown member type: " + member.GetType().Name);
+            if (member is EnumDeclarationSyntax @enum) return @enum.Modifiers;
+            return new SyntaxTokenList();
         }
 
         private StaticOrder? GetStaticOrder(MemberDeclarationSyntax member)


### PR DESCRIPTION

Ie when having an `operator==()`. That will currently lead to a warning, better to just ignore them.

When running "fix order" they will end up in the bottom.