### PR TITLE
Order by interfaces

### DIFF
--- a/Trine.Analyzer.Tests/MemberOrderTests.cs
+++ b/Trine.Analyzer.Tests/MemberOrderTests.cs
@@ -132,6 +132,52 @@ namespace Trine
             VerifyCSharpFix(test, fixtest);
         }
 
+        [TestMethod]
+        public void WhenImplementingInterface()
+        {
+            var source = @"
+                interface ITest 
+                {
+                    void A();
+                    void B();
+                }
+
+                interface ITest2
+                {
+                    void C();
+                }
+
+                class Test : ITest, ITest2
+                {
+                    public void C() {}
+                    public void B() {}
+                    public void A() {}
+                }
+            ";
+            var @fixed = @"
+                interface ITest 
+                {
+                    void A();
+                    void B();
+                }
+
+                interface ITest2
+                {
+                    void C();
+                }
+
+                class Test : ITest, ITest2
+                {
+                    public void A() {}
+
+                    public void B() {}
+
+                    public void C() {}
+                }
+            ";
+            VerifyCSharpFix(source, @fixed);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new MemberOrderCodeFixProvider();

--- a/Trine.Analyzer/MemberOrderAnalyzer.cs
+++ b/Trine.Analyzer/MemberOrderAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Trine.Analyzer
             SortOrder prevSortOrder = null;
             foreach (var member in cls.Members)
             {
-                var sortOrder = new SortOrder(member);
+                var sortOrder = new SortOrder(member, context.SemanticModel);
                 if (prevSortOrder != null
                     && prevSortOrder.IsKnown
                     && sortOrder.IsKnown

--- a/Trine.Analyzer/MemberOrderCodeFixProvider.cs
+++ b/Trine.Analyzer/MemberOrderCodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace Trine.Analyzer
                 .Select(member => new
                 {
                     Member = member,
-                    SortOrder = new SortOrder(member)
+                    SortOrder = new SortOrder(member, semanticModel)
                 })
                 .OrderBy(member => member.SortOrder)
                 .Select(member =>

--- a/Trine.Analyzer/SyntaxExtensions.cs
+++ b/Trine.Analyzer/SyntaxExtensions.cs
@@ -7,8 +7,8 @@ namespace Trine.Analyzer
         public static ClassDeclarationSyntax AddSortedMembers(this ClassDeclarationSyntax classNode, MemberDeclarationSyntax member)
         {
             var updatedMembers = classNode.Members;
-            var currentSortOrder = new SortOrder(member);
-            var insertIndex = updatedMembers.IndexOf(otherMember => new SortOrder(otherMember).CompareTo(currentSortOrder) >= 0);
+            var currentSortOrder = new SortOrder(member, null);
+            var insertIndex = updatedMembers.IndexOf(otherMember => new SortOrder(otherMember, null).CompareTo(currentSortOrder) >= 0);
             if (insertIndex == -1) insertIndex = updatedMembers.Count;
             updatedMembers = updatedMembers.Insert(insertIndex, member);
             return classNode.WithMembers(updatedMembers);


### PR DESCRIPTION

Follow order of implemented interfaces, and member order inside of interface, when comparing implementation. See test case for example.