### PR TITLE
Revert target framework

### DIFF
--- a/Trine.Analyzer/Trine.Analyzer.csproj
+++ b/Trine.Analyzer/Trine.Analyzer.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <!-- CG: For some reason only seems to work with VS Code if we target netstandard1.3 -->
+    <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION

Seems like `netstandard2.1` doesn't work with VS Code. So reverting to `netstandard1.3`.