### PR TITLE
Better error message on incorrect "interface order"

### DIFF
--- a/Trine.Analyzer.Tests/MemberOrderTests.cs
+++ b/Trine.Analyzer.Tests/MemberOrderTests.cs
@@ -178,6 +178,72 @@ namespace Trine
             VerifyCSharpFix(source, @fixed);
         }
 
+
+        [TestMethod]
+        public void InterfaceOrder()
+        {
+            var test = @"
+namespace Trine
+{
+    public interface I1
+    {
+        void TestI1_1();
+        void TestI1_2();
+    }
+    public interface I2
+    {
+        void TestI2();
+    }
+    public class TestClass : I1, I2
+    {
+        public void TestI2() { }
+        public void TestI1_2() { }
+        public void TestI1_1() { }
+    }
+}
+";
+            VerifyCSharpDiagnostic(test, new[]{
+                new DiagnosticResult
+                {
+                    Id = "TRINE01",
+                    Message = "I1.TestI1_2 should be declared before I2.TestI2",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 16, 9)}
+                },
+                new DiagnosticResult
+                {
+                    Id = "TRINE01",
+                    Message = "I1.TestI1_1 should be declared before I1.TestI1_2",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] {new DiagnosticResultLocation("Test0.cs", 17, 9)}
+                },
+            });
+
+            var fixtest = @"
+namespace Trine
+{
+    public interface I1
+    {
+        void TestI1_1();
+        void TestI1_2();
+    }
+    public interface I2
+    {
+        void TestI2();
+    }
+    public class TestClass : I1, I2
+    {
+        public void TestI1_1() { }
+
+        public void TestI1_2() { }
+
+        public void TestI2() { }
+    }
+}
+";
+            VerifyCSharpFix(test, fixtest);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new MemberOrderCodeFixProvider();

--- a/Trine.Analyzer/MemberOrderAnalyzer.cs
+++ b/Trine.Analyzer/MemberOrderAnalyzer.cs
@@ -35,7 +35,10 @@ namespace Trine.Analyzer
                     && sortOrder.IsKnown
                     && sortOrder.CompareTo(prevSortOrder) < 0)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation(), SortOrder.FormatOrderDifference(sortOrder, prevSortOrder)));
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Rule,
+                        member.GetLocation(),
+                        SortOrder.FormatOrderDifference(sortOrder, prevSortOrder)));
                 }
 
                 prevSortOrder = sortOrder;


### PR DESCRIPTION

Instead of `0 should be declared before 1` it will now include the name of the interface and method, i.e. `IGiven.This should be declared before `IThen.That`.