### PR TITLE
Null reference error fix

### DIFF
--- a/Trine.Analyzer/SortOrder.cs
+++ b/Trine.Analyzer/SortOrder.cs
@@ -188,6 +188,9 @@ namespace Trine.Analyzer
                     i.GetMembers().Any(m => classSymbol.FindImplementationForInterfaceMember(m) == methodSymbol)
                 );
 
+            // CG: For some reason the interface couldn't be found in all cases.
+            // Couldn't figure out why, but for now just ignoring.
+            if (@interface == null) return methodSymbol.Name;
             return @interface.Name + "." + methodSymbol.Name;
         }
 


### PR DESCRIPTION
https://github.com/jointrine/trine/pull/5422 failed because of this:

```
CSC : error AD0001: Analyzer 'Trine.Analyzer.MemberOrderAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'
```

For some reason the interface can't be found for this method in `TestSubscriberStorage.cs`:

```c#
public int Track(int eventId, Type subscriber, SubscriptionStatus status)
```

So for now just avoiding error when that happens.