### PR TITLE
If brackets analyzer

### DIFF
--- a/Trine.Analyzer.Tests/BracketTests.cs
+++ b/Trine.Analyzer.Tests/BracketTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Trine.Analyzer.Tests.TestHelper;
+using Trine.Analyzer;
+using System;
+
+namespace Trine.Analyzer.Tests
+{
+    [TestClass]
+    public class BracketTests : CodeFixVerifier
+    {
+        [TestMethod]
+        public void NoDiagnosticsWhenCorrect()
+        {
+            var source = @"class X { void Test() { if (true) { return; } } }";
+
+            VerifyCSharpDiagnostic(source);
+        }
+
+        [TestMethod]
+        public void DiagnosticsWhenMissingBrackets()
+        {
+            var source = @"class X { void Test() { if (true) return; } }";
+
+            VerifyCSharpDiagnostic(source, new DiagnosticResult
+            {
+                Id = "TRINE03",
+                Message = "Missing brackets",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 1, 35) }
+            });
+        }
+
+        [DataTestMethod]
+        [DataRow(
+"if (true) return;",
+@"if (true)
+{
+    return;
+}")]
+
+        [DataRow(
+"if (true) { return 1; } else return 2;",
+@"if (true) { return 1; } else
+{
+    return 2;
+}")]
+
+        [DataRow(
+"if (true) return 1; else return 2;",
+@"if (true)
+{
+    return 1;
+}
+else
+{
+    return 2;
+}")]
+        [DataRow(
+@"if (true) 
+    return 1;",
+@"if (true)
+{
+    return 1;
+}")]
+        public void VerifyFixer(string source, string fixedSource)
+        {
+            VerifyCSharpFix(WrapStatementsInMethod(source), WrapStatementsInMethod(fixedSource));
+        }
+
+        private string WrapStatementsInMethod(string code)
+        {
+            return $@"class X 
+{{ 
+    void Test() 
+    {{ 
+        {code.Replace(Environment.NewLine, Environment.NewLine + new string(' ', 8))}
+    }} 
+}}";
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new BracketCodeFixProvider();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new BracketAnalyzer();
+        }
+    }
+}

--- a/Trine.Analyzer/BracketAnalyzer.cs
+++ b/Trine.Analyzer/BracketAnalyzer.cs
@@ -14,7 +14,13 @@ namespace Trine.Analyzer
     {
         public const string DiagnosticId = "TRINE03";
 
-        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, "Missing brackets", "Missing brackets", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            "Missing brackets",
+            "Missing brackets",
+            "Category",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -28,7 +34,10 @@ namespace Trine.Analyzer
         {
             var ifStatementSyntax = (IfStatementSyntax)context.Node;
             AnalyzeStatement(context, ifStatementSyntax.Statement);
-            if (ifStatementSyntax.Else != null) AnalyzeStatement(context, ifStatementSyntax.Else.Statement);
+            if (ifStatementSyntax.Else != null)
+            {
+                AnalyzeStatement(context, ifStatementSyntax.Else.Statement);
+            }
         }
 
         private static void AnalyzeStatement(SyntaxNodeAnalysisContext context, StatementSyntax statement)

--- a/Trine.Analyzer/BracketAnalyzer.cs
+++ b/Trine.Analyzer/BracketAnalyzer.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Trine.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BracketAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "TRINE03";
+
+        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, "Missing brackets", "Missing brackets", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
+        }
+
+        private static void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
+        {
+            var ifStatementSyntax = (IfStatementSyntax)context.Node;
+            AnalyzeStatement(context, ifStatementSyntax.Statement);
+            if (ifStatementSyntax.Else != null) AnalyzeStatement(context, ifStatementSyntax.Else.Statement);
+        }
+
+        private static void AnalyzeStatement(SyntaxNodeAnalysisContext context, StatementSyntax statement)
+        {
+            var missingBrackets = !statement.IsKind(SyntaxKind.Block);
+            if (missingBrackets)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, statement.GetLocation()));
+            }
+        }
+    }
+}

--- a/Trine.Analyzer/BracketCodeFixProvider.cs
+++ b/Trine.Analyzer/BracketCodeFixProvider.cs
@@ -47,7 +47,10 @@ namespace Trine.Analyzer
                             .Distinct();
                         foreach (var statement in statementsToFix)
                         {
-                            if (statement == null) continue;
+                            if (statement == null)
+                            {
+                                continue;
+                            }
 
                             var updatedStatement = SyntaxFactory.Block(statement);
                             var updatedParent = statement.Parent.ReplaceNode(statement, updatedStatement);

--- a/Trine.Analyzer/BracketCodeFixProvider.cs
+++ b/Trine.Analyzer/BracketCodeFixProvider.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Trine.Analyzer
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BracketCodeFixProvider)), Shared]
+    public class BracketCodeFixProvider : CodeFixProvider
+    {
+        private const string title = "Add brackets";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(BracketAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: async ct =>
+                    {
+                        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                        var semanticModel = await context.Document.GetSemanticModelAsync();
+
+                        var statementsToFix = context.Diagnostics
+                            .Select(d => root.FindNode(d.Location.SourceSpan) as StatementSyntax)
+                            .Distinct();
+                        foreach (var statement in statementsToFix)
+                        {
+                            if (statement == null) continue;
+
+                            var updatedStatement = SyntaxFactory.Block(statement);
+                            var updatedParent = statement.Parent.ReplaceNode(statement, updatedStatement);
+
+                            root = root.ReplaceNode(statement, updatedStatement);
+                        }
+                        return context.Document.WithSyntaxRoot(root);
+                    },
+                    equivalenceKey: title),
+                context.Diagnostics);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION

If statements should always be wrapped in brackets (see [code sync](https://docs.google.com/document/d/1io2UTdHOf0LzMQAWeIzqp2R0fytMIh0GaoOvw3shjCc/edit#heading=h.1tkb9da0i1xs))
```c#
if (...) return 1;
```

Fixed:
```c#
if (...)
{
    return 1;
}
```