### PR TITLE
Allow for else if without brackets

### DIFF
--- a/Trine.Analyzer.SolutionFixer/Program.cs
+++ b/Trine.Analyzer.SolutionFixer/Program.cs
@@ -27,10 +27,15 @@ namespace SolutionFixer
             MSBuildLocator.RegisterDefaults();
 
             var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
-                new MemberOrderAnalyzer(), new EnumValueAnalyzer());
+                new MemberOrderAnalyzer(),
+                new EnumValueAnalyzer(),
+                new BracketAnalyzer()
+                );
             var codeFixProviders = ImmutableArray.Create<CodeFixProvider>(
                 new MemberOrderCodeFixProvider(),
-                new EnumValueCodeFixProvider());
+                new EnumValueCodeFixProvider(),
+                new BracketCodeFixProvider()
+                );
 
             using (var workspace = MSBuildWorkspace.Create())
             {

--- a/Trine.Analyzer.Tests/BracketTests.cs
+++ b/Trine.Analyzer.Tests/BracketTests.cs
@@ -11,11 +11,11 @@ namespace Trine.Analyzer.Tests
     [TestClass]
     public class BracketTests : CodeFixVerifier
     {
-        [TestMethod]
-        public void NoDiagnosticsWhenCorrect()
+        [DataTestMethod]
+        [DataRow("class X { void Test() { if (true) { return; } } }")]
+        [DataRow("class X { void Test() { if (true) { return; } else if { return; } } }")]
+        public void NoDiagnosticsWhenCorrect(string source)
         {
-            var source = @"class X { void Test() { if (true) { return; } } }";
-
             VerifyCSharpDiagnostic(source);
         }
 

--- a/Trine.Analyzer/BracketAnalyzer.cs
+++ b/Trine.Analyzer/BracketAnalyzer.cs
@@ -34,7 +34,8 @@ namespace Trine.Analyzer
         {
             var ifStatementSyntax = (IfStatementSyntax)context.Node;
             AnalyzeStatement(context, ifStatementSyntax.Statement);
-            if (ifStatementSyntax.Else != null)
+            if (ifStatementSyntax.Else != null &&
+                !ifStatementSyntax.Else.Statement.IsKind(SyntaxKind.IfStatement))
             {
                 AnalyzeStatement(context, ifStatementSyntax.Else.Statement);
             }


### PR DESCRIPTION

```c#
else if (...)
{
}
```

shouldn't require extra brackets around `if`:
```c#
else
{
    if (...)
    {
    }
}
```

(Also adding bracket analyzer to solution fixer)