### PR TITLE
Don't include reference to self in NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Trine.Analyzer" Version="2020.4.9.2" />
+    <PackageReference Include="Trine.Analyzer" Version="2020.4.9.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION

Leads to errors like these:
```
C:\Users\christian\Documents\GitHub\TrineWay\src\Contracts\Contracts.csproj : error NU1108: Cycle detected.  [C:\Users\christian\Documents\GitHub\TrineWay\TrineWay.sln]
C:\Users\christian\Documents\GitHub\TrineWay\src\Contracts\Contracts.csproj : error NU1108:   TrineWay.Contracts -> Trine.Analyzer 2020.10.7.4 -> Trine.Analyzer (>= 2020.4.9.2). [C:\Users\christian\Documents\GitHub\TrineWay\TrineWay.sln]
```