### PR TITLE
Async suffix analyzer

### DIFF
--- a/Trine.Analyzer.Tests/AsyncSuffixTests.cs
+++ b/Trine.Analyzer.Tests/AsyncSuffixTests.cs
@@ -15,6 +15,8 @@ namespace Trine.Analyzer.Tests
         [DataRow("class X { Task TestAsync() { return Task.CompletedTask; } }")]
         [DataRow("class X { System.Task TestAsync() { return System.Task.CompletedTask; } }")]
         [DataRow("class X { System.Task<int> TestAsync() { return System.Task.FromResult(1); } }")]
+        [DataRow("class X { IAsyncEnumerable<int> TestAsync() {  } }")]
+        [DataRow("class Program { static async Task Main() { return Task.CompletedTask; } }")]
         public void NoDiagnosticsWhenCorrect(string source)
         {
             VerifyCSharpDiagnostic(source);
@@ -30,7 +32,7 @@ namespace Trine.Analyzer.Tests
                 Id = "TRINE04",
                 Message = "Invalid Async suffix",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 1, 11) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 1, 23) }
             });
         }
 
@@ -44,6 +46,9 @@ namespace Trine.Analyzer.Tests
         [DataRow(
             "void TestAsync() { }", 
             "void Test() { }")]
+        [DataRow(
+            "void TestAsync() { } void Go() { TestAsync(); }", 
+            "void Test() { } void Go() { Test(); }")]
         public void VerifyFixer(string source, string fixedSource)
         {
             VerifyCSharpFix(WrapStatementsInClass(source), WrapStatementsInClass(fixedSource));

--- a/Trine.Analyzer.Tests/AsyncSuffixTests.cs
+++ b/Trine.Analyzer.Tests/AsyncSuffixTests.cs
@@ -14,6 +14,7 @@ namespace Trine.Analyzer.Tests
         [DataRow("class X { void Test() { } }")]
         [DataRow("class X { Task TestAsync() { return Task.CompletedTask; } }")]
         [DataRow("class X { System.Task TestAsync() { return System.Task.CompletedTask; } }")]
+        [DataRow("class X { System.Task<int> TestAsync() { return System.Task.FromResult(1); } }")]
         public void NoDiagnosticsWhenCorrect(string source)
         {
             VerifyCSharpDiagnostic(source);

--- a/Trine.Analyzer.Tests/AsyncSuffixTests.cs
+++ b/Trine.Analyzer.Tests/AsyncSuffixTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Trine.Analyzer.Tests.TestHelper;
+
+namespace Trine.Analyzer.Tests
+{
+    [TestClass]
+    public class AsyncSuffixTests : CodeFixVerifier
+    {
+        [DataTestMethod]
+        [DataRow("class X { void Test() { } }")]
+        [DataRow("class X { Task TestAsync() { return Task.CompletedTask; } }")]
+        [DataRow("class X { System.Task TestAsync() { return System.Task.CompletedTask; } }")]
+        public void NoDiagnosticsWhenCorrect(string source)
+        {
+            VerifyCSharpDiagnostic(source);
+        }
+
+        [TestMethod]
+        public void DiagnosticsWhenMissingAsync()
+        {
+            var source = @"class X { System.Task Test() { return System.Task.CompletedTask; } }";
+
+            VerifyCSharpDiagnostic(source, new DiagnosticResult
+            {
+                Id = "TRINE04",
+                Message = "Invalid Async suffix",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 1, 11) }
+            });
+        }
+
+        [DataTestMethod]
+        [DataRow(
+            "System.Task Test() { return System.Task.CompletedTask; }", 
+            "System.Task TestAsync() { return System.Task.CompletedTask; }")]
+        [DataRow(
+            "Task Test() { return Task.CompletedTask; }", 
+            "Task TestAsync() { return Task.CompletedTask; }")]
+        [DataRow(
+            "void TestAsync() { }", 
+            "void Test() { }")]
+        public void VerifyFixer(string source, string fixedSource)
+        {
+            VerifyCSharpFix(WrapStatementsInClass(source), WrapStatementsInClass(fixedSource));
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new AsyncSuffixCodeFixProvider();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new AsyncSuffixAnalyzer();
+        }
+
+        private string WrapStatementsInClass(string code)
+        {
+            return $@"class X 
+{{ 
+    {code.Replace(Environment.NewLine, Environment.NewLine + new string(' ', 8))}
+}}";
+        }
+    }
+}

--- a/Trine.Analyzer/AsyncSuffixAnalyzer.cs
+++ b/Trine.Analyzer/AsyncSuffixAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Trine.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AsyncSuffixAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "TRINE04";
+
+        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            "Invalid Async suffix",
+            "Invalid Async suffix",
+            "Category",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        }
+
+        internal static bool IsTask(TypeSyntax type)
+        {
+            if (type is QualifiedNameSyntax qualifiedNameSyntax)
+            {
+                return IsTask(qualifiedNameSyntax.Right);
+            }
+
+            if (type is IdentifierNameSyntax identifierNameSyntax)
+            {
+                return identifierNameSyntax.Identifier.Text == "Task";
+            }
+            return false;
+        }
+
+        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            var methodSyntax = (MethodDeclarationSyntax)context.Node;
+            var returnsTask = IsTask(methodSyntax.ReturnType);
+            var hasAsyncSuffix = methodSyntax.Identifier.Text.EndsWith("Async");
+            if (returnsTask != hasAsyncSuffix)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, methodSyntax.GetLocation()));
+            }
+        }
+    }
+}

--- a/Trine.Analyzer/AsyncSuffixAnalyzer.cs
+++ b/Trine.Analyzer/AsyncSuffixAnalyzer.cs
@@ -29,16 +29,12 @@ namespace Trine.Analyzer
 
         internal static bool IsTask(TypeSyntax type)
         {
-            if (type is QualifiedNameSyntax qualifiedNameSyntax)
+            return type switch
             {
-                return IsTask(qualifiedNameSyntax.Right);
-            }
-
-            if (type is IdentifierNameSyntax identifierNameSyntax)
-            {
-                return identifierNameSyntax.Identifier.Text == "Task";
-            }
-            return false;
+                QualifiedNameSyntax qualifiedNameSyntax => IsTask(qualifiedNameSyntax.Right),
+                SimpleNameSyntax simpleNameSyntax => simpleNameSyntax.Identifier.Text == "Task",
+                _ => false
+            };
         }
 
         private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)

--- a/Trine.Analyzer/AsyncSuffixCodeFixProvider.cs
+++ b/Trine.Analyzer/AsyncSuffixCodeFixProvider.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Trine.Analyzer
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncSuffixCodeFixProvider)), Shared]
+    public class AsyncSuffixCodeFixProvider : CodeFixProvider
+    {
+        private const string title = "Update Async suffix";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(AsyncSuffixAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: async ct =>
+                    {
+                        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                        var semanticModel = await context.Document.GetSemanticModelAsync();
+
+                        var methodsToFix = context.Diagnostics
+                            .Select(d => root.FindNode(d.Location.SourceSpan) as MethodDeclarationSyntax)
+                            .Distinct();
+                        foreach (var method in methodsToFix)
+                        {
+                            if (method == null)
+                            {
+                                continue;
+                            }
+
+                            var updatedMethod = method.WithIdentifier(FixIdentifier(method));
+
+                            root = root.ReplaceNode(method, updatedMethod);
+                        }
+                        return context.Document.WithSyntaxRoot(root);
+                    },
+                    equivalenceKey: title),
+                context.Diagnostics);
+            return Task.CompletedTask;
+        }
+
+        private SyntaxToken FixIdentifier(MethodDeclarationSyntax method)
+        {
+            var isTask = AsyncSuffixAnalyzer.IsTask(method.ReturnType);
+            var methodName = method.Identifier.Text;
+            var newName = isTask 
+                ? methodName + "Async" 
+                : methodName.Substring(0, methodName.Length - "Async".Length);
+            return SyntaxFactory.Identifier(newName);
+        }
+    }
+}


### PR DESCRIPTION
Trine.Analyzer will now warn about incorrect async suffix, i.e. the following is wrong:

```c#
public Task Method() {}
public void MethodAsync() {}
```

(When live we can get rid of the Rider/Resharper rule that also warns about this, but very annoyingly)